### PR TITLE
Apply HEAD/MENU/FOOT constants in admin pages

### DIFF
--- a/admin/ajustes/index.php
+++ b/admin/ajustes/index.php
@@ -2,14 +2,13 @@
 require_once __DIR__ . '/../init.php';
 
 $usuario = $_SESSION['usuario_nombre'] ?? 'Administrador';
+
+require HEAD;
+require MENU;
 ?>
 
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <title>Ajustes del Sistema</title>
-    <style>
+<div class="main-content">
+<style>
         body {
             font-family: 'Segoe UI', sans-serif;
             background: #f4f4f4;
@@ -46,9 +45,7 @@ $usuario = $_SESSION['usuario_nombre'] ?? 'Administrador';
         a:hover {
             text-decoration: underline;
         }
-    </style>
-</head>
-<body>
+</style>
 <div class="container">
     <h2>⚙️ Ajustes del Sistema</h2>
     <ul>
@@ -59,5 +56,6 @@ $usuario = $_SESSION['usuario_nombre'] ?? 'Administrador';
         <li><a href="servicios.php">📋 Tipos de Servicios</a></li>
     </ul>
 </div>
-</body>
-</html>
+
+</div>
+<?php require FOOT; ?>

--- a/admin/ajustes/tecnicos.php
+++ b/admin/ajustes/tecnicos.php
@@ -55,14 +55,14 @@ foreach ($roles_stmt as $rol) {
 ?>
 
 <!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <title>Gestión de Técnicos</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
-<div class="container py-5">
+require HEAD;
+require MENU;
+?>
+
+<div class="main-content">
+    <h2>👨‍🔧 Gestión de Técnicos / Usuarios</h2>
+
+    <div class="card mt-4">
     <h2>👨‍🔧 Gestión de Técnicos / Usuarios</h2>
 
     <div class="card mt-4">
@@ -142,5 +142,6 @@ foreach ($roles_stmt as $rol) {
         </tbody>
     </table>
 </div>
-</body>
-</html>
+
+</div>
+<?php require FOOT; ?>

--- a/admin/carga.php
+++ b/admin/carga.php
@@ -1,11 +1,10 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8">
-  <title>Carga de Servicios - OMNIPOS</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
+<?php
+require_once __DIR__ . '/init.php';
+require HEAD;
+require MENU;
+?>
+
+<div class="main-content">
 
 <div class="container py-5">
   <h2 class="text-center mb-5">Carga de Servicios</h2>
@@ -48,6 +47,4 @@
   </div>
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+<?php require FOOT; ?>

--- a/admin/carga_azteca.php
+++ b/admin/carga_azteca.php
@@ -1,5 +1,15 @@
-<h2>Carga Servicios Azteca</h2>
-<form action="importar_azteca.php" method="post" enctype="multipart/form-data">
-  <input type="file" name="archivo_csv" required>
-  <button type="submit">Subir y Cargar</button>
-</form>
+<?php
+require_once __DIR__ . '/init.php';
+require HEAD;
+require MENU;
+?>
+
+<div class="main-content">
+    <h2>Carga Servicios Azteca</h2>
+    <form action="importar_azteca.php" method="post" enctype="multipart/form-data">
+      <input type="file" name="archivo_csv" required>
+      <button type="submit">Subir y Cargar</button>
+    </form>
+</div>
+
+<?php require FOOT; ?>

--- a/admin/carga_banregio.php
+++ b/admin/carga_banregio.php
@@ -1,5 +1,15 @@
-<h2>Carga Servicios Banregio</h2>
-<form action="importar_banregio.php" method="post" enctype="multipart/form-data">
-  <input type="file" name="archivo_csv" required>
-  <button type="submit">Subir y Cargar</button>
-</form>
+<?php
+require_once __DIR__ . '/init.php';
+require HEAD;
+require MENU;
+?>
+
+<div class="main-content">
+    <h2>Carga Servicios Banregio</h2>
+    <form action="importar_banregio.php" method="post" enctype="multipart/form-data">
+      <input type="file" name="archivo_csv" required>
+      <button type="submit">Subir y Cargar</button>
+    </form>
+</div>
+
+<?php require FOOT; ?>

--- a/admin/carga_bbva.php
+++ b/admin/carga_bbva.php
@@ -1,11 +1,10 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8">
-  <title>Cargar Servicios BBVA - OMNIPOS</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
+<?php
+require_once __DIR__ . '/init.php';
+require HEAD;
+require MENU;
+?>
+
+<div class="main-content">
 
 <div class="container py-5">
 
@@ -48,6 +47,4 @@
 
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+<?php require FOOT; ?>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,34 +1,13 @@
 <?php
 require_once __DIR__ . '/init.php';
 
-
-
 $usuario = $_SESSION['usuario_nombre'] ?? 'Administrador';
+
+require HEAD;
+require MENU;
 ?>
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <title>Panel Admin - OMNIPOS</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
 
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top">
-    <div class="container-fluid">
-        <span class="navbar-brand">OMNIPOS - Admin</span>
-        <div class="collapse navbar-collapse justify-content-end">
-            <ul class="navbar-nav mb-2 mb-lg-0">
-                <li class="nav-item">
-                    <a class="nav-link" href="/logout.php">Cerrar sesión</a>
-                </li>
-            </ul>
-        </div>
-    </div>
-</nav>
-
-<div class="container" style="margin-top: 80px;">
+<div class="main-content" style="margin-top: 80px;">
     <div class="alert alert-success">
         👋 Bienvenido, <strong><?= htmlspecialchars($usuario) ?></strong>. Este es tu panel de administración.
     </div>
@@ -53,7 +32,4 @@ $usuario = $_SESSION['usuario_nombre'] ?? 'Administrador';
 </div>
 <!-- Deploy automático funcionando: <?php echo date("Y-m-d H:i:s"); ?> -->
 
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+<?php require FOOT; ?>

--- a/admin/importar_bbva.php
+++ b/admin/importar_bbva.php
@@ -151,15 +151,12 @@ function procesarFila($data, $pdo, &$insertados, &$errores) {
 }
 ?>
 
-<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8">
-  <title>Resultado de la Carga BBVA - OMNIPOS</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
+<?php
+require HEAD;
+require MENU;
+?>
 
+<div class="main-content">
 <div class="container py-5">
 
   <div class="row justify-content-center">
@@ -193,10 +190,9 @@ function procesarFila($data, $pdo, &$insertados, &$errores) {
 
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <form method="POST" action="migrar_a_omnipos.php">
   <button type="submit" class="btn btn-success btn-lg mt-3">🚀 Copiar a Servicios OMNIPOS</button>
 </form>
 
-</body>
-</html>
+</div>
+<?php require FOOT; ?>

--- a/admin/layout.php
+++ b/admin/layout.php
@@ -1,19 +1,9 @@
 <?php
 $usuario = $_SESSION['usuario_nombre'] ?? 'Administrador';
-?>
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <title>Panel Admin - OMNIPOS</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- Tailwind o Bootstrap -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
 
-<!-- Menu lateral -->
-<?php include __DIR__ . '/includes/menu.php'; ?>
+require HEAD;
+require MENU;
+?>
 
 <!-- Header -->
 <nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top" style="margin-left: 250px;"> <!-- 250px porque el sidebar mide eso -->
@@ -35,5 +25,5 @@ $usuario = $_SESSION['usuario_nombre'] ?? 'Administrador';
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+
+<?php require FOOT; ?>

--- a/admin/minidrive/index.php
+++ b/admin/minidrive/index.php
@@ -1,13 +1,12 @@
 <?php
 $dir = __DIR__;
 $archivos = array_diff(scandir($dir), ['.', '..', 'index.php']);
+
+require HEAD;
+require MENU;
 ?>
 
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <title>MiniDrive - Archivos Frecuentes</title>
+<div class="main-content">
     <style>
         body { font-family: Arial; padding: 20px; background: #f9f9f9; }
         h2 { color: #333; }
@@ -16,13 +15,11 @@ $archivos = array_diff(scandir($dir), ['.', '..', 'index.php']);
         a { text-decoration: none; color: #007bff; font-weight: bold; }
         a:hover { text-decoration: underline; }
     </style>
-</head>
-<body>
     <h2>📁 MiniDrive - Archivos Frecuentes</h2>
     <ul>
         <?php foreach ($archivos as $archivo): ?>
             <li>📄 <a href="<?= $archivo ?>" download><?= $archivo ?></a></li>
         <?php endforeach; ?>
     </ul>
-</body>
-</html>
+</div>
+<?php require FOOT; ?>

--- a/admin/servicios.php
+++ b/admin/servicios.php
@@ -12,21 +12,16 @@ $validTabs = ['por_asignar', 'en_ruta', 'concluido', 'agendar_cita'];
 if (!in_array($tab, $validTabs)) {
     $tab = 'por_asignar';
 }
+require HEAD;
+require MENU;
 ?>
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <title>Gestión de Servicios - OMNIPOS</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+
+<div class="main-content">
+    <h3 class="mb-4">Gestión de Servicios</h3>
     <style>
         .nav-link.active { font-weight: bold; }
     </style>
-</head>
-<body class="bg-light">
-<div class="container mt-4">
-    <h3 class="mb-4">Gestión de Servicios</h3>
+    <div class="container mt-4">
 
     <ul class="nav nav-tabs mb-3">
         <li class="nav-item">
@@ -47,5 +42,4 @@ if (!in_array($tab, $validTabs)) {
         <?php include "servicios/{$tab}.php"; ?>
     </div>
 </div>
-</body>
-</html>
+<?php require FOOT; ?>

--- a/admin/servicios/control.php
+++ b/admin/servicios/control.php
@@ -1,8 +1,9 @@
 <?php
 require '../auth.php';
 require '../config.php';
-require '../includes/header.php';
-require '../includes/menu.php';
+
+require HEAD;
+require MENU;
 ?>
 
 <div class="main-content">
@@ -45,4 +46,4 @@ require '../includes/menu.php';
     </div>
 </div>
 
-<?php require '../includes/footer.php'; ?>
+<?php require FOOT; ?>

--- a/admin/servicios/servicios.php
+++ b/admin/servicios/servicios.php
@@ -4,6 +4,7 @@ header_remove('X-Powered-By');
 ini_set('expose_php', 'Off');
 
 require_once __DIR__ . '/../../config.php';
+
 session_start();
 
 // Validar sesión
@@ -15,20 +16,15 @@ if (!isset($_SESSION['usuario_id'])) {
 // ¿Qué tab estamos cargando?
 $tab = $_GET['tab'] ?? 'por_asignar';
 
+require HEAD;
+require MENU;
 ?>
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <title>Gestión de Servicios</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <style>
-        body {
-            padding: 20px;
-        }
-    </style>
-</head>
-<body>
+
+<div class="main-content">
+    <h1>Gestión de Servicios</h1>
+
+    <!-- Tabs de navegación -->
+    <ul class="nav nav-tabs mb-4">
 
 <h1>Gestión de Servicios</h1>
 
@@ -69,5 +65,4 @@ switch ($tab) {
 ?>
 </div>
 
-</body>
-</html>
+<?php require FOOT; ?>

--- a/config.php
+++ b/config.php
@@ -10,6 +10,11 @@ define('DB_USER', 'enodhcdl_omn');
 define('DB_PASS', 'Z00Q_8F^r0');
 define('DB_CHARSET', 'utf8mb4');
 
+// Template paths
+define('HEAD', __DIR__ . '/includes/header.php');
+define('MENU', __DIR__ . '/includes/menu.php');
+define('FOOT', __DIR__ . '/includes/footer.php');
+
 // =============================================
 // CONEXI0ˆ7N SEGURA CON PDO
 // =============================================
@@ -29,10 +34,6 @@ try {
     
 } catch (PDOException $e) {
 
-// Template paths
-define('HEAD', __DIR__ . '/includes/header.php');
-define('MENU', __DIR__ . '/includes/menu.php');
-define('FOOT', __DIR__ . '/includes/footer.php');
     error_log("Error de conexi¨®n DB [" . date('Y-m-d H:i:s') . "]: " . $e->getMessage());
     die("<h2>Error en el sistema. Por favor intente m¨¢s tarde.</h2>");
 }


### PR DESCRIPTION
## Summary
- define template path constants unconditionally
- refactor admin pages to use `HEAD`, `MENU` and `FOOT`

## Testing
- `php -l` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848746b22048325ba1545cf8f1c7cf4