### PR TITLE
Fix admin init paths

### DIFF
--- a/admin/ajustes/index.php
+++ b/admin/ajustes/index.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../init.php';
+require_once dirname(__DIR__, 2) . '/admin/init.php';
 
 $usuario = $_SESSION['usuario_nombre'] ?? 'Administrador';
 

--- a/admin/ajustes/tecnicos.php
+++ b/admin/ajustes/tecnicos.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../init.php';
+require_once dirname(__DIR__, 2) . '/admin/init.php';
 
 // Función para resetear contraseña
 function hashPassword($plain) {


### PR DESCRIPTION
## Summary
- reference admin init from the project root

## Testing
- `php -l admin/ajustes/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ad0da48483258d91a3088caea5fa