### PR TITLE
Fix duplicate FOOTER_INCLUDED constant

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -1,5 +1,15 @@
 <?php
 require_once __DIR__ . '/header.php';
 require_once __DIR__ . '/menu.php';
-require_once __DIR__ . '/footer.php';
+
+function include_footer_once(): void {
+    if (!defined('FOOTER_INCLUDED')) {
+        require_once __DIR__ . '/footer.php';
+        if (!defined('FOOTER_INCLUDED')) {
+            define('FOOTER_INCLUDED', true);
+        }
+    }
+}
+
+include_footer_once();
 ?>


### PR DESCRIPTION
## Summary
- add include_footer_once helper in `includes/init.php`
- guard FOOTER_INCLUDED constant inside the helper

## Testing
- `php -l includes/init.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ad0c105483259b86831ad0c97049