### PR TITLE
Improve closing service module

### DIFF
--- a/tecnico/bloques/mis_servicios_lista.php
+++ b/tecnico/bloques/mis_servicios_lista.php
@@ -1,3 +1,9 @@
+<?php if (!empty($mensaje)): ?>
+  <div class="bg-green-100 text-green-800 p-3 rounded mb-4 text-sm text-center">
+    <?= htmlspecialchars($mensaje) ?>
+  </div>
+<?php endif; ?>
+
 <?php if (empty($servicios)): ?>
   <div class="text-gray-500 text-center mt-8">
     No tienes servicios en ruta asignados.
@@ -46,13 +52,11 @@
              🔍 Ver detalle
           </a>
 
-          <form action="cerrar_servicio.php" method="POST" onsubmit="return confirm('¿Seguro que quieres cerrar este servicio?');">
-            <input type="hidden" name="ticket" value="<?= htmlspecialchars($serv['ticket']) ?>">
-            <button type="submit"
-              class="flex-1 text-center bg-green-100 text-green-700 py-2 px-3 rounded-xl text-sm font-medium hover:bg-green-200 transition">
-              ✅ Cerrar
-            </button>
-          </form>
+          <a href="cerrar_servicio.php?ticket=<?= urlencode($serv['ticket']) ?>"
+             class="flex-1 text-center bg-green-100 text-green-700 py-2 px-3 rounded-xl text-sm font-medium hover:bg-green-200 transition"
+             onclick="return confirm('¿Seguro que quieres cerrar este servicio?');">
+            ✅ Cerrar
+          </a>
         </div>
       </div>
     <?php endforeach; ?>

--- a/tecnico/generar_hs.php
+++ b/tecnico/generar_hs.php
@@ -40,6 +40,7 @@ $placeholders = [
   '{{vim}}' => $servicio['vim'] ?? '',
   '{{serie_instalada}}' => $servicio['serie_instalada'] ?? '',
   '{{serie_retiro}}' => $servicio['serie_retiro'] ?? '',
+  '{{serie_retirada}}' => $servicio['serie_retiro'] ?? '',
   '{{cantidad_insumos}}' => $servicio['cantidad_insumos'] ?? '',
   '{{idc}}' => $servicio['idc'] ?? '',
   '{{servicio}}' => $servicio['servicio'] ?? '',

--- a/tecnico/mis_servicios.php
+++ b/tecnico/mis_servicios.php
@@ -15,6 +15,10 @@ if (!$idc) {
 }
 
 $contenido = __DIR__ . '/bloques/mis_servicios_lista.php';
+$mensaje = null;
+if (isset($_GET['cerrado'])) {
+    $mensaje = '✅ Servicio cerrado correctamente.';
+}
 
 $stmt = $pdo->prepare("
 SELECT ticket, afiliacion, comercio, ciudad, telefono_contacto_1, servicio, vim, fecha_cita, banco

--- a/tecnico/procesar_cierre.php
+++ b/tecnico/procesar_cierre.php
@@ -5,6 +5,9 @@ require_once __DIR__ . '/init.php';
 $ticket = $_POST['ticket'] ?? null;
 $atiende = trim($_POST['atiende'] ?? '');
 $resultado = $_POST['resultado'] ?? '';
+$serie_instalada = trim($_POST['serie_instalada'] ?? '');
+$serie_retiro = trim($_POST['serie_retirada'] ?? '');
+$observaciones = trim($_POST['observaciones'] ?? '');
 $usuario = $_SESSION['usuario_nombre'] ?? null;
 
 if (!$ticket || !$atiende || !$usuario || !in_array($resultado, ['Éxito', 'Rechazo'])) {
@@ -27,10 +30,22 @@ $update = $pdo->prepare("
     SET estatus = 'Histórico',
         resultado = ?,
         atiende = ?,
-        fecha_atencion = NOW()
-    WHERE ticket = ?
+        serie_instalada = ?,
+        serie_retiro = ?,
+        comentarios = ?,
+        fecha_atencion = NOW(),
+        fecha_cierre = NOW()
+    WHERE ticket = ? AND idc = ?
 ");
-$update->execute([$resultado, $atiende, $ticket]);
+$update->execute([
+    $resultado,
+    $atiende,
+    $serie_instalada,
+    $serie_retiro,
+    $observaciones,
+    $ticket,
+    $usuario
+]);
 
 header("Location: mis_servicios.php?cerrado=1");
 exit;


### PR DESCRIPTION
## Summary
- show message when a service gets closed
- use a regular link for closing a service
- record installed/removed series and comments when closing
- allow service sheet generation to use `serie_retirada`

## Testing
- `php -l tecnico/procesar_cierre.php`
- `php -l tecnico/mis_servicios.php`
- `php -l tecnico/bloques/mis_servicios_lista.php`
- `php -l tecnico/generar_hs.php`
- `php -l tecnico/cerrar_servicio.php`

------
https://chatgpt.com/codex/tasks/task_e_688249421ca08325a1cfa616c1bd1f78